### PR TITLE
Fix rename

### DIFF
--- a/src/gridftp_hdfs.c
+++ b/src/gridftp_hdfs.c
@@ -455,6 +455,7 @@ hdfs_command(
                 if (errno == EIO) {
                     hdfsDelete(hdfs_handle->fs, PathName, 0);
                     failed = hdfsRename(hdfs_handle->fs, FromPathName, PathName);
+                    result = GLOBUS_SUCCESS;
                 }
                 if (failed) {
                     char * rename_msg = (char *)globus_malloc(1024);


### PR DESCRIPTION
Make rename overwrite the destination file (the correct semantics for FTP).  Note this is not necessarily atomic (but we can't fix that in the current HDFS version).
