### PR TITLE
Add support for `CVMFS` checksum type

### DIFF
--- a/conf/gridftp-hdfs
+++ b/conf/gridftp-hdfs
@@ -30,7 +30,7 @@
 
 # Comment out the following line to disable on-the-fly GridFTP checksum calculations
 # Alternately, remove one or more checksum format from the list to reduce CPU usage.
-export GRIDFTP_HDFS_CHECKSUMS="MD5,ADLER32,CRC32,CKSUM"
+export GRIDFTP_HDFS_CHECKSUMS="MD5,ADLER32,CRC32,CKSUM,CVMFS"
 
 # By default, reduce the amount of memory that HDFS uses for its embedded JVM.
 # This is typically a safe setting as long as the process only has one file

--- a/src/gridftp_hdfs.c
+++ b/src/gridftp_hdfs.c
@@ -838,6 +838,7 @@ hdfs_destroy(
             globus_free(hdfs_handle->mutex);
         }
         globus_free(hdfs_handle);
+        free(hdfs_handle->cvmfs_graft);
     }
     closelog();
 }

--- a/src/gridftp_hdfs.h
+++ b/src/gridftp_hdfs.h
@@ -11,6 +11,7 @@
 #include <hdfs.h>
 #include <stdint.h>
 #include <openssl/md5.h>
+#include <openssl/evp.h>
 
 #include "globus_gridftp_server.h"
 #include "gridftp_hdfs_error.h"
@@ -34,6 +35,9 @@ extern globus_version_t gridftp_hdfs_local_version;
 #define HDFS_CKSM_TYPE_CRC32   2
 #define HDFS_CKSM_TYPE_ADLER32 4
 #define HDFS_CKSM_TYPE_MD5     8
+// Create checksums compatible with CVMFS's grafting tool; allows easy publication of files
+// from HDFS into CVMFS.
+#define HDFS_CKSM_TYPE_CVMFS   16
 
 typedef struct globus_l_gfs_hdfs_handle_s
 {
@@ -82,6 +86,15 @@ typedef struct globus_l_gfs_hdfs_handle_s
     MD5_CTX                             md5;
     char                                md5_output[MD5_DIGEST_LENGTH];
     char                                md5_output_human[MD5_DIGEST_LENGTH*2+1];
+    EVP_MD_CTX                         *file_sha1;
+    EVP_MD_CTX                         *chunk_sha1;
+    char                                file_sha1_human[EVP_MAX_MD_SIZE*2+1];
+    char                              **chunk_sha1_human;
+    globus_size_t                       cur_chunk_bytes;
+    globus_size_t                      *chunk_offsets;
+    globus_size_t                       chunk_count;
+    globus_size_t                       chunk_array_size;
+    char                               *cvmfs_graft;
     uint32_t                            adler32;
     char                                adler32_human[2*sizeof(uint32_t)+1];
     uint32_t                            crc32;

--- a/src/gridftp_hdfs_cksm.c
+++ b/src/gridftp_hdfs_cksm.c
@@ -342,8 +342,7 @@ hdfs_calculate_checksum(hdfs_handle_t *hdfs_handle, hdfsFS fs, const char *type)
 
     GlobusGFSName(hdfs_calculate_checksum);
 
-    hdfs_parse_checksum_types(hdfs_handle, type);
-    hdfs_initialize_checksum(hdfs_handle);
+    hdfs_initialize_checksums(hdfs_handle);
 
     hdfsFile fd = hdfsOpenFile(fs, hdfs_handle->pathname, O_RDONLY, 0, 1, 0);
     if (fd == NULL) {
@@ -359,11 +358,13 @@ hdfs_calculate_checksum(hdfs_handle_t *hdfs_handle, hdfsFS fs, const char *type)
         return rc;
     }
     ssize_t retval = 0;
+    globus_off_t offset = 0;
     do {
-        hdfs_udpate_checksums(hdfs_handle, buffer, retval);
+        hdfs_update_checksums(hdfs_handle, buffer, retval);
         errno = 0;  // older versions of libhdfs sometimes fails to reset errno.
         retval = hdfsRead(fs, fd, buffer, cksum_buffer_size);
         if ((retval == -1) && (errno == EINTR)) {continue;}
+        offset += retval;
     } while (retval > 0);
     if (retval == -1) {
         SystemError(hdfs_handle, "Failed to read from file for checksumming", rc);
@@ -372,6 +373,8 @@ hdfs_calculate_checksum(hdfs_handle_t *hdfs_handle, hdfsFS fs, const char *type)
     hdfsCloseFile(fs, fd);
 
     if (rc == GLOBUS_SUCCESS) {
+        hdfs_handle->offset = offset;
+        hdfs_finalize_checksums(hdfs_handle);
         rc = hdfs_save_checksum(hdfs_handle);
     }
     return rc;
@@ -388,7 +391,7 @@ globus_result_t hdfs_get_checksum(hdfs_handle_t *hdfs_handle, const char * pathn
 
     hdfsFS fs = hdfsConnectAsUser("default", 0, "root");
     if (fs == NULL) {
-        SystemError(hdfs_handle, "Failure in connecting to HDFS for checksum upload", rc);
+        SystemError(hdfs_handle, "Failure in connecting to HDFS for checksumming.", rc);
         return rc;
     }
 

--- a/src/gridftp_hdfs_cksm.c
+++ b/src/gridftp_hdfs_cksm.c
@@ -15,7 +15,7 @@
 #define CVMFS_CHUNK_SIZE (24*1024*1024)
 
 // TODO: resizable output buffer.
-#define OUTPUT_BUFFER_SIZE (32*1024)
+#define OUTPUT_BUFFER_SIZE (128*1024)
 
 // CRC table taken from POSIX description of algorithm.
 static uint32_t const crctab[256] =

--- a/src/gridftp_hdfs_cksm.c
+++ b/src/gridftp_hdfs_cksm.c
@@ -115,7 +115,7 @@ static void emit_cvmfs_chunk(hdfs_handle_t *hdfs_handle) {
     if (hdfs_handle->chunk_count == 1) {
         hdfs_handle->chunk_offsets[hdfs_handle->chunk_count-1] = 0;
     } else {
-        hdfs_handle->chunk_offsets[hdfs_handle->chunk_count-1] = hdfs_handle->chunk_offsets[hdfs_handle->chunk_count-2] + hdfs_handle->cur_chunk_bytes;
+        hdfs_handle->chunk_offsets[hdfs_handle->chunk_count-1] = hdfs_handle->chunk_offsets[hdfs_handle->chunk_count-2] + CVMFS_CHUNK_SIZE;
     }
     unsigned char sha1_value[EVP_MAX_MD_SIZE];
     int sha1_len;


### PR DESCRIPTION
This introduces the `CVMFS` checksum type.  This "checksum" is actually a sequence of N SHA-1 checksums, one per every 24MB of data.

The resulting checksum value can be queried using `uberftp` in order to publish the corresponding file into CVMFS.